### PR TITLE
Feature - Service container nesting (2.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,21 @@ $cache = $container->get('cache'); // DateTime object
 ```
 
 
+### Isolated extension to service container
+
+A use-case: you want to create a new container inheriting services from the existing one. 
+But you don't want to re-define the services again, using the originally defined ones.
+Also you want to provide more services, without modifying the original container.
+
+Think of it as JavaScript variables scopes: a nested scope inherits all the variables from parent scope.
+But defining new scope variables won't modify the parent scope. That's it.
+
+```php
+$layer = new ServiceContainerLayer($existing_container);
+$layer->set('configuration', $layer_configuration); 
+$layer->bindResolver('layer_scope_service', ...);
+// and so on
+```      
 
 ### Automatic dependency injection 
 

--- a/README.md
+++ b/README.md
@@ -182,11 +182,17 @@ Think of it as JavaScript variables scopes: a nested scope inherits all the vari
 But defining new scope variables won't modify the parent scope. That's it.
 
 ```php
+$parent = new ServiceContainer();
+$parent->set('configuration', $global_configuration);
+
 $layer = new ServiceContainerLayer($existing_container);
 $layer->set('configuration', $layer_configuration); 
 $layer->bindResolver('layer_scope_service', ...);
 // and so on
+
+var_dump($parent->get('configuration') === $layer->get('configuration')); // "false"
 ```      
+
 
 ### Automatic dependency injection 
 

--- a/src/ServiceContainerLayer.php
+++ b/src/ServiceContainerLayer.php
@@ -32,9 +32,10 @@ class ServiceContainerLayer extends ServiceContainer implements ServiceContainer
     /**
      * @param string $id
      *
-     * @return mixed
      * @throws \RockSymphony\ServiceContainer\Exceptions\BindingNotFoundException
      * @throws \RockSymphony\ServiceContainer\Exceptions\BindingResolutionException
+     *
+     * @return mixed
      */
     public function get($id)
     {
@@ -59,9 +60,10 @@ class ServiceContainerLayer extends ServiceContainer implements ServiceContainer
      * @param string $abstract
      * @param array  $parameters
      *
-     * @return mixed
      * @throws \RockSymphony\ServiceContainer\Exceptions\BindingNotFoundException
      * @throws \RockSymphony\ServiceContainer\Exceptions\BindingResolutionException
+     *
+     * @return mixed
      */
     public function resolve($abstract, array $parameters = [])
     {

--- a/src/ServiceContainerLayer.php
+++ b/src/ServiceContainerLayer.php
@@ -1,0 +1,84 @@
+<?php
+namespace RockSymphony\ServiceContainer;
+
+use RockSymphony\ServiceContainer\Interfaces\ServiceContainerInterface;
+
+/**
+ * ServiceContainerLayer allows to construct an extension to an existing Service Container.
+ * The new instance will inherit parent service container definitions (at call-time).
+ * All the new added or modified services will modify the extension container only,
+ * keeping the original one untouched.
+ */
+class ServiceContainerLayer extends ServiceContainer implements ServiceContainerInterface
+{
+    /** @var \RockSymphony\ServiceContainer\Interfaces\ServiceContainerInterface */
+    private $parentLayer;
+
+    public function __construct(ServiceContainerInterface $parentLayer)
+    {
+        $this->parentLayer = $parentLayer;
+    }
+
+    /**
+     * @param string $id
+     *
+     * @return bool
+     */
+    public function has($id)
+    {
+        return parent::has($id) || $this->parentLayer->has($id);
+    }
+
+    /**
+     * @param string $id
+     *
+     * @return mixed
+     * @throws \RockSymphony\ServiceContainer\Exceptions\BindingNotFoundException
+     * @throws \RockSymphony\ServiceContainer\Exceptions\BindingResolutionException
+     */
+    public function get($id)
+    {
+        // If it's bound to THIS layer, resolve it.
+        // This layer takes priority.
+        if (parent::has($id)) {
+            return parent::get($id);
+        }
+
+        // If it's bound to PARENT layer, resolve it there.
+        // Getting a known service from parent level is better
+        // than re-resolving it here.
+        if ($this->parentLayer->has($id)) {
+            return $this->parentLayer->get($id);
+        }
+
+        // Otherwise, let the `get()` fail on getting an unknown layer
+        return parent::get($id);
+    }
+
+    /**
+     * @param string $abstract
+     * @param array  $parameters
+     *
+     * @return mixed
+     * @throws \RockSymphony\ServiceContainer\Exceptions\BindingNotFoundException
+     * @throws \RockSymphony\ServiceContainer\Exceptions\BindingResolutionException
+     */
+    public function resolve($abstract, array $parameters = [])
+    {
+        // If it's bound to THIS layer, resolve it.
+        // This layer takes priority.
+        if (parent::has($abstract)) {
+            return parent::resolve($abstract, $parameters);
+        }
+
+        // If it's bound to PARENT layer, resolve it there.
+        // Getting a known service from parent level is better
+        // than re-resolving it here.
+        if ($this->parentLayer->has($abstract)) {
+            return $this->parentLayer->resolve($abstract, $parameters);
+        }
+
+        // Otherwise, resolve the service from scratch here.
+        return parent::resolve($abstract, $parameters);
+    }
+}

--- a/tests/LayerTest.php
+++ b/tests/LayerTest.php
@@ -1,0 +1,185 @@
+<?php
+namespace RockSymphony\ServiceContainer\Tests;
+
+use PHPUnit\Framework\TestCase;
+use RockSymphony\ServiceContainer\ServiceContainerLayer;
+use RockSymphony\ServiceContainer\ServiceContainer;
+use RockSymphony\ServiceContainer\Tests\Support\DummyCache;
+use RockSymphony\ServiceContainer\Tests\Support\DummyFilesystem;
+use RockSymphony\ServiceContainer\Tests\Support\DummyFilesystemDecorator;
+
+class LayerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_should_inherit_parent_layer_services()
+    {
+        $parent = new ServiceContainer();
+        $parent->set('test_instance', $this);
+
+        $layer = new ServiceContainerLayer($parent);
+
+        $this->assertTrue($layer->has('test_instance'));
+        $this->assertSame($this, $layer->get('test_instance'));
+    }
+    /**
+     * @test
+     */
+    public function it_should_inherit_parent_layer_service_resolvers()
+    {
+        $parent = new ServiceContainer();
+        $parent->bindResolver('test_resolver', function () {
+            return $this;
+        });
+
+        $layer = new ServiceContainerLayer($parent);
+
+        $this->assertTrue($layer->has('test_resolver'));
+        $this->assertSame($this, $layer->get('test_resolver'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_define_new_services_on_the_lower_layer_only()
+    {
+        $parent = new ServiceContainer();
+        $parent->set('test_instance', $this);
+
+        $layer = new ServiceContainerLayer($parent);
+
+        $this->assertTrue($layer->has('test_instance'));
+
+        $test_override = new \stdClass();
+
+        $layer->set('test_instance', $test_override);
+
+        // "test_instance" is overriden
+        $this->assertTrue($layer->has('test_instance'));
+        $this->assertSame($test_override, $layer->get('test_instance'));
+
+        // parent "test_instance" is not changed
+        $this->assertTrue($parent->has('test_instance'));
+        $this->assertSame($this, $parent->get('test_instance'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_define_new_service_resolvers_on_the_lower_layer()
+    {
+        $parent = new ServiceContainer();
+        $parent->bindResolver('test_resolver', function () {
+            return $this;
+        });
+
+        $layer = new ServiceContainerLayer($parent);
+
+        $this->assertTrue($layer->has('test_resolver'));
+
+        $test_override = new \stdClass();
+
+        $layer->bindResolver('test_resolver', function () use ($test_override) {
+            return $test_override;
+        });
+
+        // "test_instance" is overriden
+        $this->assertTrue($layer->has('test_resolver'));
+        $this->assertSame($test_override, $layer->get('test_resolver'));
+
+        // parent "test_instance" is not changed
+        $this->assertTrue($parent->has('test_resolver'));
+        $this->assertSame($this, $parent->get('test_resolver'));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_resolve_services_recursively_inheriting_definitions()
+    {
+        $local_filesystem = new DummyFilesystem('/', 'local');
+
+        $parent = new ServiceContainer();
+        $parent->bindResolver(DummyFilesystem::CLASS_NAME, function () use ($local_filesystem) {
+            return $local_filesystem;
+        });
+
+        $layer = new ServiceContainerLayer($parent);
+
+        // 1) resolve Decorator using parent service container
+        /** @var DummyFilesystemDecorator $decorated_filesystem */
+        $decorated_filesystem = $parent->resolve(DummyFilesystemDecorator::CLASS_NAME);
+        $this->assertSame($local_filesystem, $decorated_filesystem->filesystem);
+
+        // 2) resolve Decorator using lower layer service container
+        /** @var DummyFilesystemDecorator $layer_decorated_filesystem */
+        $layer_decorated_filesystem = $layer->resolve(DummyFilesystemDecorator::CLASS_NAME);
+        $this->assertNotSame($decorated_filesystem, $layer_decorated_filesystem);
+        $this->assertSame($local_filesystem, $layer_decorated_filesystem->filesystem);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_resolve_services_recursively_preferring_lower_level()
+    {
+        $local_filesystem = new DummyFilesystem('/', 'local');
+        $ssh_filesystem = new DummyFilesystem('/mnt/ssh', 'ssh');
+
+        $parent = new ServiceContainer();
+        $parent->bindResolver(DummyFilesystem::CLASS_NAME, function () use ($local_filesystem) {
+            return $local_filesystem;
+        });
+
+        $layer = new ServiceContainerLayer($parent);
+        $layer->bindResolver(DummyFilesystem::CLASS_NAME, function () use ($ssh_filesystem) {
+            return $ssh_filesystem;
+        });
+
+        // 1) resolve Decorator using parent service container
+        /** @var DummyFilesystemDecorator $decorated_filesystem */
+        $decorated_filesystem = $parent->resolve(DummyFilesystemDecorator::CLASS_NAME);
+        $this->assertSame($local_filesystem, $decorated_filesystem->filesystem);
+
+        // 2) resolve Decorator using lower layer service container
+        /** @var DummyFilesystemDecorator $layer_decorated_filesystem */
+        $layer_decorated_filesystem = $layer->resolve(DummyFilesystemDecorator::CLASS_NAME);
+        $this->assertNotSame($decorated_filesystem, $layer_decorated_filesystem);
+        $this->assertSame($ssh_filesystem, $layer_decorated_filesystem->filesystem);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_resolve_inherited_services_recursively_using_inherited_definitions_only()
+    {
+        $local_filesystem = new DummyFilesystem('/', 'local');
+        $ssh_filesystem = new DummyFilesystem('/mnt/ssh', 'ssh');
+
+        $parent = new ServiceContainer();
+        $parent->bindResolver(DummyFilesystem::CLASS_NAME, function () use ($local_filesystem) {
+            return $local_filesystem;
+        });
+        // Decorator is now defined on the parent layer
+        $parent->bindResolver(DummyFilesystemDecorator::CLASS_NAME, function () use ($parent) {
+            return $parent->construct(DummyFilesystemDecorator::CLASS_NAME);
+        });
+
+        $layer = new ServiceContainerLayer($parent);
+        $layer->bindResolver(DummyFilesystem::CLASS_NAME, function () use ($ssh_filesystem) {
+            return $ssh_filesystem;
+        });
+
+        // 1) resolve Decorator using parent service container
+        /** @var DummyFilesystemDecorator $decorated_filesystem */
+        $decorated_filesystem = $parent->resolve(DummyFilesystemDecorator::CLASS_NAME);
+        $this->assertSame($local_filesystem, $decorated_filesystem->filesystem);
+
+        // 2) resolve Decorator using lower layer service container => it should ignore lower layer Filesystem
+        /** @var DummyFilesystemDecorator $layer_decorated_filesystem */
+        $layer_decorated_filesystem = $layer->resolve(DummyFilesystemDecorator::CLASS_NAME);
+        $this->assertNotSame($decorated_filesystem, $layer_decorated_filesystem);
+        $this->assertSame($local_filesystem, $layer_decorated_filesystem->filesystem);
+    }
+}

--- a/tests/LayerTest.php
+++ b/tests/LayerTest.php
@@ -2,9 +2,8 @@
 namespace RockSymphony\ServiceContainer\Tests;
 
 use PHPUnit\Framework\TestCase;
-use RockSymphony\ServiceContainer\ServiceContainerLayer;
 use RockSymphony\ServiceContainer\ServiceContainer;
-use RockSymphony\ServiceContainer\Tests\Support\DummyCache;
+use RockSymphony\ServiceContainer\ServiceContainerLayer;
 use RockSymphony\ServiceContainer\Tests\Support\DummyFilesystem;
 use RockSymphony\ServiceContainer\Tests\Support\DummyFilesystemDecorator;
 
@@ -23,6 +22,7 @@ class LayerTest extends TestCase
         $this->assertTrue($layer->has('test_instance'));
         $this->assertSame($this, $layer->get('test_instance'));
     }
+
     /**
      * @test
      */


### PR DESCRIPTION
### Isolated extension to service container

A use-case: you want to create a new container inheriting services from the existing one. 
But you don't want to re-define the services again, using the originally defined ones.
Also you want to provide more services, without modifying the original container.

Think of it as JavaScript variables scopes: a nested scope inherits all the variables from parent scope.
But defining new scope variables won't modify the parent scope. That's it.

```php
$parent = new ServiceContainer();
$parent->set('configuration', $global_configuration);

$layer = new ServiceContainerLayer($existing_container);
$layer->set('configuration', $layer_configuration); 
$layer->bindResolver('layer_scope_service', ...);
// and so on

var_dump($parent->get('configuration') === $layer->get('configuration')); // "false"
```      
